### PR TITLE
user-agent-header [master] Add option to add user agent header from initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Afterpay.configure do |config|
   # Sets the environment for Afterpay
   # defaults to sandbox
   # config.env = "sandbox" # "live"
+
+  # Sets the user agent header for Afterpay requests
+  # Refer https://docs.afterpay.com/au-online-api-v1.html#configuration
+  # config.user_agent_header = {pluginOrModuleOrClientLibrary}/{pluginVersion} ({platform}/{platformVersion}; Merchant/{merchantId}) { merchantUrl }
+  # Example
+  # config.user_agent_header = "Afterpay Module / 1.0.0 (rails/ 5.1.2; Merchant/#{ merchant_id }) #{ merchant_website_url }"
+
 end
 ```
 

--- a/lib/afterpay/client.rb
+++ b/lib/afterpay/client.rb
@@ -43,6 +43,7 @@ module Afterpay
         Faraday.new(url: self.class.server_url) do |conn|
           conn.use ErrorMiddleware if Afterpay.config.raise_errors
           conn.authorization "Basic", self.class.auth_token
+          conn.headers['User-Agent'] = Afterpay.config.user_agent_header if Afterpay.config.user_agent_header.present?
 
           conn.request :json
           conn.response :json, content_type: "application/json", parser_options: { symbolize_names: true }

--- a/lib/afterpay/config.rb
+++ b/lib/afterpay/config.rb
@@ -4,7 +4,8 @@ module Afterpay
   class Config
     attr_accessor :app_id, :secret, :env, :raise_errors,
                   :type, :maximum_amount, :minimum_amount,
-                  :description, :currency, :skip_remote_config
+                  :description, :currency, :skip_remote_config,
+                  :user_agent_header
 
     def initialize
       @env = "sandbox"


### PR DESCRIPTION
Added feature to add User-Agent header to all requests sent to afterpay from afterpay-ruby gem. Refer https://docs.afterpay.com/au-online-api-v1.html#get-configuration. Afterpay requires user agent header to help with customer support and troubleshooting.